### PR TITLE
Streamline Fly.io deploy task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,22 +100,38 @@ jobs:
     needs: [lint, test, security]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    
+
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: ${{ env.ELIXIR_VERSION }}
+        otp-version: ${{ env.OTP_VERSION }}
+
+    - name: Install dependencies
+      run: mix deps.get
+
+    - name: Set build tag
+      id: vars
+      run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push image
+      run: mix dagger.deploy
+      env:
+        DAGGER_LOG_FORMAT: plain
+        GIT_SHA: ${{ steps.vars.outputs.sha }}
+
     - name: Setup Fly CLI
       uses: superfly/flyctl-actions/setup-flyctl@master
-    
-    - name: Verify Fly.io configuration
-      run: flyctl config validate
-      env:
-        FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-    
+
     - name: Deploy to Fly.io
-      run: flyctl deploy --remote-only --wait-timeout 300
+      run: |
+        APP_NAME=$(grep -Po '^app\s*=\s*"\K[^"]+' fly.toml)
+        flyctl deploy --image registry.fly.io/${APP_NAME}:${{ steps.vars.outputs.sha }} --wait-timeout 300
       env:
         FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ mix dagger.test             # Run tests
 
 # CI verification (run exact same pipeline as CI)
 mix dagger.ci               # Complete CI pipeline locally
+mix dagger.deploy          # Build and push image to Fly.io (tagged with commit SHA)
 ```
 
 **📖 For detailed development workflows, see [Dagger Integration Guide](lib/gatherly/dagger/README.md)**

--- a/agent-rules.md
+++ b/agent-rules.md
@@ -154,41 +154,29 @@ end
 
 ### Setup Commands
 ```bash
-# Get dependencies with latest versions
-mix deps.get
+# One-command container setup and start
+mix dagger.dev
 
-# Setup database
-mix ecto.setup
-
-# Install assets (no Node.js required)
-mix assets.setup
-
-# Start development server
-mix phx.server
+# Start/stop services only
+mix dagger.dev.start
+mix dagger.dev.stop
 ```
 
 ### Testing Commands
 ```bash
-# Run all tests
-mix test
+# Full CI pipeline inside containers
+mix dagger.ci
 
-# Run with coverage
-mix test --cover
-
-# Test specific module
-mix test test/my_app_web/live/page_live_test.exs
+# Run tests only
+mix dagger.test
 ```
 
 ### Code Quality
 ```bash
-# Format code
-mix format
-
-# Run linter
-mix credo --strict
-
-# Type checking
-mix dialyzer
+mix dagger.format          # Format code
+mix dagger.lint --strict   # Lint with Credo & Dialyzer
+mix dagger.security        # Security audit
+mix dagger.deploy          # Build & push Fly.io image
 ```
 
 ## Security Best Practices

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -38,7 +38,8 @@ Runs the test suite:
 
 Deploys to Fly.io:
 - Only runs on pushes to the `main` branch after lint and test jobs pass
-- Uses Fly.io CLI to deploy the application
+- Builds and pushes the release image with `mix dagger.deploy`
+- Deploys the commit-tagged image using the Fly CLI
 - Runs database migrations automatically
 
 ## Required Secrets
@@ -100,10 +101,12 @@ fly postgres attach gatherly-db --app gatherly
 
 ### Manual Deployment
 
-To deploy manually:
+To deploy manually, first build and push the image using Dagger and then deploy the published image:
 
 ```bash
-fly deploy
+mix dagger.deploy
+GIT_SHA=$(git rev-parse --short HEAD)
+fly deploy --image registry.fly.io/<app-name>:$GIT_SHA
 ```
 
 ### Automatic Deployment

--- a/lib/gatherly/dagger/README.md
+++ b/lib/gatherly/dagger/README.md
@@ -70,6 +70,10 @@ mix dagger.ci                    # Full CI: setup → quality → test
 # Environment-specific
 mix dagger.ci --env=test
 mix dagger.ci --skip-dialyzer    # Faster CI
+
+### Deploying to Fly.io
+```bash
+mix dagger.deploy  # pushes registry.fly.io/<app-name>:<git_sha>
 ```
 
 ## Key Features

--- a/lib/gatherly/dagger/deploy.ex
+++ b/lib/gatherly/dagger/deploy.ex
@@ -1,0 +1,92 @@
+defmodule Gatherly.Dagger.Deploy do
+  @moduledoc """
+  Build and push a production image to Fly.io using Dagger.
+
+  This module exposes a single `deploy/1` function which automatically
+  reads the Fly.io `app` name from `fly.toml`. The current source is built
+  into a release image and pushed to the Fly.io registry under two tags:
+  `registry.fly.io/<app_name>:<git_sha>` and `registry.fly.io/<app_name>:latest`.
+  Authentication must be handled beforehand
+  via `fly auth docker`.
+
+  ## Examples
+
+      {:ok, client} = Gatherly.Dagger.Client.connect()
+      Gatherly.Dagger.Deploy.deploy(client)
+
+  The same functionality is available via `mix dagger.deploy`.
+  """
+
+  import Gatherly.Dagger.Workflow
+  alias Gatherly.Dagger.{Client, Containers}
+  alias Dagger.Container
+
+  @runtime_image "elixir:1.18.4-otp-28-slim"
+
+  @spec deploy(Dagger.Client.t()) :: {:ok, String.t()} | {:error, term()}
+  def deploy(client) do
+    with {:ok, app_name} <- fly_app_name() do
+      do_deploy(client, app_name)
+    end
+  end
+
+  defp fly_app_name do
+    with {:ok, content} <- File.read("fly.toml"),
+         [_, app] <- Regex.run(~r/^app\s*=\s*"([^"]+)"/m, content) do
+      {:ok, app}
+    else
+      _ -> {:error, :app_not_found}
+    end
+  end
+
+  defp git_sha do
+    case System.cmd("git", ["rev-parse", "--short", "HEAD"]) do
+      {sha, 0} -> String.trim(sha)
+      _ -> "unknown"
+    end
+  end
+
+  defp do_deploy(client, app_name) do
+    sha = git_sha()
+    tagged = "registry.fly.io/#{app_name}:#{sha}"
+    latest = "registry.fly.io/#{app_name}:latest"
+
+    log_step("Building release image", :start)
+
+    builder =
+      client
+      |> Containers.elixir_base()
+      |> Container.with_env_variable("MIX_ENV", "prod")
+      |> with_source(client)
+      |> Container.with_exec(["mix", "deps.get", "--only", "prod"])
+      |> Container.with_exec(["mix", "deps.compile"])
+      |> Container.with_exec(["mix", "assets.setup"])
+      |> Container.with_exec(["mix", "assets.deploy"])
+      |> Container.with_exec(["mix", "compile"])
+      |> Container.with_exec(["mix", "phx.digest"])
+      |> Container.with_exec(["mix", "release"])
+
+    release_dir = Container.directory(builder, "/app/_build/prod/rel/gatherly")
+
+    runtime =
+      client
+      |> Client.container([])
+      |> Container.from(@runtime_image)
+      |> Container.with_exec(["apt-get", "update"])
+      |> Container.with_exec(["apt-get", "install", "-y", "postgresql-client", "openssl"])
+      |> Container.with_exec(["groupadd", "-r", "app"])
+      |> Container.with_exec(["useradd", "-r", "-g", "app", "app"])
+      |> Container.with_workdir("/app")
+      |> Container.with_directory("/app", release_dir)
+      |> Container.with_user("app")
+      |> Container.with_exposed_port(8080)
+      |> Container.with_entrypoint(["./bin/gatherly", "start"])
+
+    log_step("Tagging image as #{tagged} and #{latest}")
+    {:ok, _digest} = Container.publish(runtime, tagged)
+    {:ok, _} = Container.publish(runtime, latest)
+    log_step("Image pushed to Fly.io registry", :finish)
+
+    {:ok, tagged}
+  end
+end

--- a/lib/mix/tasks/dagger/deploy.ex
+++ b/lib/mix/tasks/dagger/deploy.ex
@@ -1,0 +1,33 @@
+defmodule Mix.Tasks.Dagger.Deploy do
+  @shortdoc "Build and push image to Fly.io"
+
+  @moduledoc """
+  Builds the production release image using Dagger and pushes it to the Fly.io
+  registry. The image is tagged with the current Git commit hash and also as
+  `latest`. Ensure you have run `fly auth docker` so registry credentials are
+  available.
+
+  ## Examples
+
+      mix dagger.deploy
+  """
+
+  use Mix.Task
+  import Gatherly.Dagger.Workflow
+  alias Gatherly.Dagger.{Client, Deploy}
+
+  @impl Mix.Task
+  def run(_args) do
+    Client.with_client(fn client ->
+      case Deploy.deploy(client) do
+        {:ok, tag} ->
+          log_step("Deployed image #{tag}", :success)
+          {:ok, tag}
+
+        {:error, reason} ->
+          log_step("Fly deploy failed: #{inspect(reason)}", :error)
+          {:error, reason}
+      end
+    end)
+  end
+end


### PR DESCRIPTION
## Summary
- rename FlyDeploy task to `dagger.deploy`
- auto-read app name from `fly.toml`
- update docs to reference `mix dagger.deploy`
- update GH Actions deploy job to use Dagger-built image
- tag Fly images with commit SHA
- document new Dagger-based developer flow in agent guidelines

## Testing
- ❌ `mix format` *(failed: Hex missing)*
- ❌ `mix dagger.ci` *(failed: Hex missing)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688c65bffd60832dbd05636837586339

## Summary by Sourcery

Introduce a unified Dagger-based deployment workflow for Fly.io by adding a new Mix task to build and push release images tagged with the current git SHA (and `latest`), updating CI and local developer commands to use Dagger, and refreshing documentation accordingly.

New Features:
- Add `Gatherly.Dagger.Deploy` module and `mix dagger.deploy` task to build and push Fly.io release images tagged with commit SHA and `latest`.
- Introduce Dagger-based Mix tasks for streamlined workflows: `dagger.dev`, `dagger.dev.start/stop`, `dagger.test`, `dagger.ci`, `dagger.format`, `dagger.lint`, and `dagger.security`.

Enhancements:
- Automatically read the Fly.io app name from `fly.toml` in the deploy pipeline.
- Update GitHub Actions to set the git SHA, run `mix dagger.deploy` for image build/push, and deploy using the commit-tagged image.

CI:
- Revise GitHub Actions deploy job to use Dagger for image building and pushing, then deploy via `flyctl deploy --image registry.fly.io/<app>:<sha>`.

Documentation:
- Update agent rules, CI/CD guide, Dagger integration guide, and README to reference the new Dagger-based commands and deployment flow.

Chores:
- Rename internal FlyDeploy task to `dagger.deploy`.