### PR TITLE
Update Dagger port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ cd gatherly
 mix dagger.dev  # Complete environment setup + start server
 ```
 
-Visit [`localhost:4000`](http://localhost:4000) to see your app running.
+The Phoenix server runs on port `4000` inside the container and Dagger
+forwards this same port to your host. When the command completes you can
+visit [`http://localhost:4000`](http://localhost:4000) in your browser.
+If another service is already using port `4000` you'll receive an error.
+The forwarding uses Dagger's `"<port>:<port>"` mapping so the external port
+always matches the Phoenix port.
 
 ### Development Workflows
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -48,12 +48,19 @@ Using Claude Code or compatible container tooling:
 
 ### 2. Accessing the Application
 
-The Phoenix server runs on port 4000 and is exposed externally. You'll receive a URL like:
+The Phoenix server listens on port `4000` inside the container. When you start
+the dev environment with `mix dagger.dev` (or `mix dagger.dev.start --detached`),
+Dagger forwards this same port to your host. You can always access the
+application at:
 
 ```
-External URL: http://127.0.0.1:50091
-Internal URL: http://container-name:4000
+http://localhost:4000
 ```
+
+If the port is unavailable you'll receive an error message instructing you to
+stop the conflicting service or pass a different `--port` value.
+Port forwarding uses Dagger's `"<port>:<port>"` syntax so the host port matches
+Phoenix's internal port.
 
 ### 3. Working with Code
 
@@ -231,7 +238,9 @@ git push origin main
 
 ### Common Issues
 
-1. **Port Already in Use**: If port 4000 is busy, the container will assign a different external port
+1. **Port Already in Use**: The dev task binds port `4000` to your host. If that port is
+   taken the command fails. Restart the conflicting service or run
+   `mix dagger.dev.start --port=<other>` to choose a different port
 2. **Database Connection**: Ensure PostgreSQL service is running within the container
 3. **Asset Issues**: Run `mix assets.setup` to reinstall asset tools
 4. **Dependency Issues**: Clear deps with `mix deps.clean --all` then `mix deps.get`

--- a/lib/mix/tasks/dagger/dev/start.ex
+++ b/lib/mix/tasks/dagger/dev/start.ex
@@ -126,16 +126,11 @@ defmodule Mix.Tasks.Dagger.Dev.Start do
   defp start_tunnel_service(_client, phoenix_service, port) do
     # Use the up() method to expose the service to host with port forwarding
     # This is the recommended way per Dagger docs for interactive development
-    case Dagger.Service.up(phoenix_service, ports: [%{frontend: port, backend: port}]) do
-      {:ok, tunnel} ->
-        case Dagger.Service.endpoint(tunnel) do
-          {:ok, endpoint} ->
-            log_step("Phoenix server started in background mode", :success)
-            log_step("Access your app at #{endpoint}", :info)
-          {:error, _} ->
-            log_step("Phoenix server started in background mode", :success)
-            log_step("Access your app at http://localhost:#{port}", :info)
-        end
+    # Forward Phoenix port directly to the same port on the host
+    case Dagger.Service.up(phoenix_service, ports: ["#{port}:#{port}"]) do
+      {:ok, _tunnel} ->
+        log_step("Phoenix server started in background mode", :success)
+        log_step("Access your app at http://localhost:#{port}", :info)
 
       {:error, reason} ->
         log_step("Failed to expose service to host: #{inspect(reason)}", :error)


### PR DESCRIPTION
## Summary
- fix tunnel service mapping with "<port>:<port>" syntax
- document how Dagger forwards port 4000 to host

## Testing
- `mix format --check-formatted` *(failed: could not install Hex)*
- `mix test` *(failed: could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_688c608e6100832da43772a2c98ab4f1

## Summary by Sourcery

Use direct "<port>:<port>" syntax for Dagger port forwarding and streamline the tunnel startup, and update documentation to clarify port mapping and error handling

Bug Fixes:
- Fix tunnel service mapping by using the correct "<port>:<port>" syntax for port forwarding

Enhancements:
- Simplify tunnel service startup code and logging to remove nested endpoint resolution

Documentation:
- Update Development.md and README.md to explain that Phoenix’s container port 4000 is forwarded directly to host, describe error on port conflict, and show consistent localhost URL