### PR TITLE
feat(auth): add X OAuth login

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -87,7 +87,8 @@ config :ueberauth, Ueberauth,
          default_scope: "email profile",
          prompt: "consent",
          access_type: "online"
-       ]}
+       ]},
+    x: {Ueberauth.Strategy.Twitter, []}
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/config/dev.secret.exs.example
+++ b/config/dev.secret.exs.example
@@ -25,6 +25,15 @@ config :ueberauth, Ueberauth.Strategy.Google.OAuth,
   client_id: "1048712597030-oajaov243289s6u852dcposka0kfrui7.apps.googleusercontent.com",
   client_secret: "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"
 
+# X OAuth credentials (get from X Developer Portal)
+config :gatherly, :x,
+  client_id: "CHANGE_ME_X_CLIENT_ID",
+  client_secret: "CHANGE_ME_X_CLIENT_SECRET"
+
+config :ueberauth, Ueberauth.Strategy.Twitter.OAuth,
+  client_id: "CHANGE_ME_X_CLIENT_ID",
+  client_secret: "CHANGE_ME_X_CLIENT_SECRET"
+
 # Authentication token signing secret (generate with: mix phx.gen.secret)
 config :ash_authentication,
   token_signing_secret: "CHANGE_ME_GENERATE_WITH_MIX_PHX_GEN_SECRET"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -124,6 +124,14 @@ if config_env() == :prod do
     client_id: System.get_env("GOOGLE_CLIENT_ID"),
     client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
 
+  config :gatherly, :x,
+    client_id: System.get_env("X_CLIENT_ID"),
+    client_secret: System.get_env("X_CLIENT_SECRET")
+
+  config :ueberauth, Ueberauth.Strategy.Twitter.OAuth,
+    client_id: System.get_env("X_CLIENT_ID"),
+    client_secret: System.get_env("X_CLIENT_SECRET")
+
   # Authentication token signing secret
   token_signing_secret =
     System.get_env("TOKEN_SIGNING_SECRET") ||
@@ -155,6 +163,16 @@ if config_env() == :dev do
   if google_client_secret = System.get_env("GOOGLE_CLIENT_SECRET") do
     config :gatherly, :google, client_secret: google_client_secret
     config :ueberauth, Ueberauth.Strategy.Google.OAuth, client_secret: google_client_secret
+  end
+
+  if x_client_id = System.get_env("X_CLIENT_ID") do
+    config :gatherly, :x, client_id: x_client_id
+    config :ueberauth, Ueberauth.Strategy.Twitter.OAuth, client_id: x_client_id
+  end
+
+  if x_client_secret = System.get_env("X_CLIENT_SECRET") do
+    config :gatherly, :x, client_secret: x_client_secret
+    config :ueberauth, Ueberauth.Strategy.Twitter.OAuth, client_secret: x_client_secret
   end
 
   if token_secret = System.get_env("TOKEN_SIGNING_SECRET") do

--- a/docs/Project.md
+++ b/docs/Project.md
@@ -79,7 +79,11 @@ Gatherly empowers every participant—not just the host—to contribute meaningf
 - [x] TailwindCSS setup
 - [x] Container-based development environment
 - [ ] Dev/test deployment (Fly.io or Render)
-- [ ] OAuth login (Google, Apple, Facebook, X)
+- [ ] OAuth login
+  - [x] Google
+  - [x] X
+  - [ ] Apple
+  - [ ] Facebook
 - [ ] Anonymous join via magic link
 
 ### Phase 1: MVP – Potluck Planning

--- a/lib/gatherly_web/components/auth_components.ex
+++ b/lib/gatherly_web/components/auth_components.ex
@@ -45,6 +45,15 @@ defmodule GatherlyWeb.AuthComponents do
           </svg>
           Sign in with Google
         </.link>
+        <.link href={~p"/auth/user/x"} class="btn btn-primary">
+          <svg class="w-4 h-4 mr-2" viewBox="0 0 24 24">
+            <path
+              fill="currentColor"
+              d="M18.9 2h3.1l-7.2 8.2L24 22h-7l-5.2-6.9L6 22H2l7.5-8.5L0 2h7l4.7 6.4L18.9 2Z"
+            />
+          </svg>
+          Sign in with X
+        </.link>
       </div>
     <% end %>
     """
@@ -98,6 +107,15 @@ defmodule GatherlyWeb.AuthComponents do
             />
           </svg>
           Sign in with Google
+        </.link>
+        <.link href={~p"/auth/user/x"} class="block mx-3 btn btn-primary">
+          <svg class="w-4 h-4 mr-2" viewBox="0 0 24 24">
+            <path
+              fill="currentColor"
+              d="M18.9 2h3.1l-7.2 8.2L24 22h-7l-5.2-6.9L6 22H2l7.5-8.5L0 2h7l4.7 6.4L18.9 2Z"
+            />
+          </svg>
+          Sign in with X
         </.link>
       </div>
     <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -111,7 +111,8 @@ defmodule Gatherly.MixProject do
 
       # OAuth dependencies for authentication
       {:ueberauth, "~> 0.10"},
-      {:ueberauth_google, "~> 0.12"}
+      {:ueberauth_google, "~> 0.12"},
+      {:ueberauth_twitter, "~> 0.10"}
     ]
   end
 


### PR DESCRIPTION
## Summary
- add ueberauth_twitter dependency and X OAuth strategy
- expose `/auth/user/x` sign-in links
- document X login progress in roadmap

## Testing
- `mix deps.get` *(fails: could_not_establish_ssl_tunnel 403 Forbidden)*
- `mix format` *(fails: Mix requires the Hex package manager to fetch dependencies)*
- `mix test` *(fails: Mix requires the Hex package manager to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689197bfa738832d8baa206c47794432

## Summary by Sourcery

Add X (Twitter) OAuth login support via Ueberauth and update related configurations, UI, and documentation.

New Features:
- Add X OAuth strategy and registration flow in the user accounts module
- Expose /auth/user/x endpoints and add sign-in buttons in the authentication UI

Enhancements:
- Configure X client credentials and Ueberauth Twitter OAuth settings in runtime and default configs

Build:
- Add ueberauth_twitter dependency to mix.exs

Documentation:
- Update Project.md roadmap to mark X OAuth login as completed